### PR TITLE
Implement basic agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,25 @@
 - Примеры двух агентов включить в дистрибутив.
 - Шаблоны юнит-тестов не требуются.
 
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+List available agents:
+
+```bash
+python dispatcher.py list
+```
+
+Run an agent with JSON input:
+
+```bash
+python dispatcher.py run get_html_agent '{"url": "https://example.com", "selector": "title"}'
+```
+
+Set `OPENAI_API_KEY` environment variable before running agents that use OpenAI.

--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -1,0 +1,61 @@
+import os
+import json
+import requests
+from abc import ABC, abstractmethod
+from datetime import datetime
+
+try:
+    import openai
+except ImportError:  # If openai isn't installed, agents that use it will fail at runtime
+    openai = None
+
+
+class BaseAgent(ABC):
+    """Base class for all agents."""
+
+    def __init__(self, config: dict, dispatcher):
+        self.config = config or {}
+        self.dispatcher = dispatcher
+
+    @abstractmethod
+    def process(self, input_data: dict):
+        """Process input data and return result."""
+        pass
+
+    def log(self, message: str, level: str = "INFO"):
+        """Log a message via dispatcher."""
+        if self.dispatcher:
+            self.dispatcher.log(level, self.__class__.__name__, message)
+
+    def openai_request(self, prompt: str, **kwargs) -> str:
+        """Send a prompt to OpenAI and return the response text."""
+        if openai is None:
+            raise RuntimeError("openai package is not installed")
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+        openai.api_key = api_key
+
+        params = {
+            "model": self.config.get("model", "gpt-3.5-turbo"),
+            "temperature": self.config.get("temperature", 0.2),
+            "max_tokens": self.config.get("max_tokens", 500),
+        }
+        params.update(kwargs)
+        messages = [{"role": "user", "content": prompt}]
+        self.log(f"Calling OpenAI with model {params['model']}")
+        resp = openai.ChatCompletion.create(messages=messages, **params)
+        content = resp.choices[0].message.content.strip()
+        self.log("Received response from OpenAI")
+        return content
+
+    def http_request(self, url: str, method: str = "GET", **kwargs) -> requests.Response:
+        """Perform an HTTP request."""
+        self.log(f"HTTP {method} request to {url}")
+        if method.upper() == "GET":
+            resp = requests.get(url, **kwargs)
+        else:
+            resp = requests.post(url, **kwargs)
+        resp.raise_for_status()
+        return resp

--- a/agents/get_html_agent.py
+++ b/agents/get_html_agent.py
@@ -1,0 +1,18 @@
+import bs4
+from .base_agent import BaseAgent
+
+
+class GetHtmlAgent(BaseAgent):
+    """Fetch HTML content by CSS selector from a URL."""
+
+    def process(self, input_data: dict):
+        url = input_data.get("url")
+        selector = input_data.get("selector")
+        if not url or not selector:
+            raise ValueError("'url' and 'selector' fields are required")
+        response = self.http_request(url)
+        soup = bs4.BeautifulSoup(response.text, "html.parser")
+        elements = soup.select(selector)
+        if not elements:
+            return ""
+        return "\n".join(str(el) for el in elements)

--- a/agents/parse_html_selectors_agent.py
+++ b/agents/parse_html_selectors_agent.py
@@ -1,0 +1,23 @@
+from .base_agent import BaseAgent
+
+
+PROMPT_TEMPLATE = (
+    "Given the following HTML snippet, return the CSS selector that matches the "
+    "element described in the instruction.\n"
+    "Instruction: {instruction}\n"
+    "HTML:\n{html}\n"
+    "Selector:" 
+)
+
+
+class ParseHtmlSelectorsAgent(BaseAgent):
+    """Return CSS selector for a given instruction and HTML."""
+
+    def process(self, input_data: dict):
+        html = input_data.get("html")
+        instruction = input_data.get("instruction")
+        if not html or not instruction:
+            raise ValueError("'html' and 'instruction' fields are required")
+        prompt = PROMPT_TEMPLATE.format(instruction=instruction, html=html)
+        selector = self.openai_request(prompt)
+        return selector

--- a/configs/agents.yaml
+++ b/configs/agents.yaml
@@ -1,0 +1,9 @@
+agents:
+  - name: get_html_agent
+    module: agents.get_html_agent
+    class: GetHtmlAgent
+    config: configs/get_html_agent.yaml
+  - name: parse_html_selectors_agent
+    module: agents.parse_html_selectors_agent
+    class: ParseHtmlSelectorsAgent
+    config: configs/parse_html_selectors_agent.yaml

--- a/configs/get_html_agent.yaml
+++ b/configs/get_html_agent.yaml
@@ -1,0 +1,2 @@
+# Configurations for GetHtmlAgent
+request_timeout: 10

--- a/configs/parse_html_selectors_agent.yaml
+++ b/configs/parse_html_selectors_agent.yaml
@@ -1,0 +1,4 @@
+# Configurations for ParseHtmlSelectorsAgent
+model: gpt-3.5-turbo
+temperature: 0.1
+max_tokens: 100

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -1,0 +1,79 @@
+import argparse
+import importlib
+import json
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+
+
+class Dispatcher:
+    def __init__(self, registry_path: Path):
+        self.registry_path = registry_path
+        self.agents = self.load_registry()
+
+    def log(self, level: str, actor: str, message: str):
+        ts = datetime.utcnow().isoformat()
+        print(f"{ts} | {level} | {actor} | {message}")
+
+    def load_registry(self):
+        with open(self.registry_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        return data.get("agents", [])
+
+    def list_agents(self):
+        for agent in self.agents:
+            print(agent["name"])
+
+    def load_agent(self, name: str):
+        entry = next((a for a in self.agents if a["name"] == name), None)
+        if not entry:
+            raise ValueError(f"Agent '{name}' not found")
+        module = importlib.import_module(entry["module"])
+        agent_cls = getattr(module, entry.get("class", name))
+        config_path = Path(entry.get("config", ""))
+        config = {}
+        if config_path.is_file():
+            with open(config_path, "r", encoding="utf-8") as f:
+                if config_path.suffix in {".yaml", ".yml"}:
+                    config = yaml.safe_load(f)
+                else:
+                    config = json.load(f)
+        return agent_cls(config, self)
+
+    def run_agent(self, name: str, input_json: str):
+        agent = self.load_agent(name)
+        input_data = json.loads(input_json)
+        self.log("INFO", name, "starting agent")
+        try:
+            result = agent.process(input_data)
+            if result is not None:
+                print(result)
+        except Exception as e:
+            self.log("ERROR", name, str(e))
+        finally:
+            self.log("INFO", name, "finished")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Agent dispatcher")
+    parser.add_argument("--registry", default="configs/agents.yaml")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="List available agents")
+
+    run_parser = subparsers.add_parser("run", help="Run an agent")
+    run_parser.add_argument("name", help="Agent name")
+    run_parser.add_argument("input", help="JSON string with input data")
+
+    args = parser.parse_args()
+    dispatcher = Dispatcher(Path(args.registry))
+
+    if args.command == "list":
+        dispatcher.list_agents()
+    elif args.command == "run":
+        dispatcher.run_agent(args.name, args.input)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai
+requests
+PyYAML
+beautifulsoup4


### PR DESCRIPTION
## Summary
- implement dispatcher CLI for managing agents
- add base agent class and utilities
- implement two sample agents: get_html_agent and parse_html_selectors_agent
- configure agent registry and sample configs
- document how to run agents

## Testing
- `python dispatcher.py list` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6842a7f592fc832abb61ae4ff41833d6